### PR TITLE
Multiple game support and installation help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-src/config.ini
+config.ini
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # wordle-bot
+
 A Discord bot to track you and your friends' Wordle scores, so you can see who's the best! To submit a score to wordle-bot, just paste the Wordle score share in a Discord server that wordle-bot is a member of, as shown in the demo photo below. Note that your scores are bound to your Discord user id, not any particular server, so you can submit a score on one server and have it shown in another server's rankings.
 
 To add the bot to your Discord server, click [here](https://discord.com/api/oauth2/authorize?client_id=933891782373158943&permissions=67584&scope=bot)!
@@ -19,3 +20,28 @@ Bot commands are as follows:
 ---
 
 ![demo of wordle-bot](demo.png)
+
+---
+
+## Installation
+
+### Prereqs
+
+- Python 3
+- MongoDB
+
+### Pre-Setup
+
+1. Register an applicaiton in the Discord Developer portal.
+2. Create a bot within the new application. On the bot page:
+   1. Give the bot a name. This will be displayed in the users list on the right in your Discord server.
+   2. Enable the "Server Members" intent and the "Message Content" intent. This will allow the bot to access people and messages to keep score.
+   3. Click the copy button in the token area of the Build-a-Bot section toward the top.
+   4. Paste this token in the config.ini file. This is how the bot will authenticate with Discord when it runs.
+3. Generate the OAuth URL for adding the bot to a server.
+   1. In the application page, click on OAuth2, then on URL Generator in the left-hand navigation.
+   2. Check the "bot" box.
+   3. Check "Send Messages" and "Read Message History" in the section that appears below.
+   4. Copy the Generated URL and browse to it to authorize the bot in your Discord server. You'll choose the server and confirm the permissions on this page.
+4. Start the bot server by running "python main.py" from the command line.
+5. In your Discord server, type "!wb" in some text channel to confirm that the bot is responding.

--- a/README.md
+++ b/README.md
@@ -27,21 +27,26 @@ Bot commands are as follows:
 
 ### Prereqs
 
-- Python 3
+- Python 3 and PIP
 - MongoDB
 
-### Pre-Setup
+### Setup
 
-1. Register an applicaiton in the Discord Developer portal.
-2. Create a bot within the new application. On the bot page:
+1. Clone this repo!
+2. Install the "discord" and the "pymongo" packages if you don't already have them.
+   1. pip install discord
+   2. pip install pymongo
+3. Start the bot server the first time by running "python src/main.py" from the command line in order to generate the config.ini file. Then stop it to configure.
+4. Register an application in the Discord Developer portal at https://discord.com/developers.
+5. Create a bot within the new application. On the bot page:
    1. Give the bot a name. This will be displayed in the users list on the right in your Discord server.
    2. Enable the "Server Members" intent and the "Message Content" intent. This will allow the bot to access people and messages to keep score.
    3. Click the copy button in the token area of the Build-a-Bot section toward the top.
    4. Paste this token in the config.ini file. This is how the bot will authenticate with Discord when it runs.
-3. Generate the OAuth URL for adding the bot to a server.
+6. Generate the OAuth URL for adding the bot to a server.
    1. In the application page, click on OAuth2, then on URL Generator in the left-hand navigation.
    2. Check the "bot" box.
    3. Check "Send Messages" and "Read Message History" in the section that appears below.
    4. Copy the Generated URL and browse to it to authorize the bot in your Discord server. You'll choose the server and confirm the permissions on this page.
-4. Start the bot server by running "python main.py" from the command line.
-5. In your Discord server, type "!wb" in some text channel to confirm that the bot is responding.
+7. Start the bot server again with the config.ini file populated by running "python src/main.py" from the command line.
+8. In your Discord server, type "!wb" in some text channel to confirm that the bot is responding.

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -6,8 +6,8 @@ class Config:
 
     def __init__(self):
         config = self.read_config()
-        self.token = config.get("wordle-bot", "token")
-        self.testtoken = config.get("wordle-bot", "testtoken")
+        self.token = config.get("wordle-bot", "token", fallback=None)
+        self.testtoken = config.get("wordle-bot", "testtoken", fallback=None)
 
     @staticmethod
     def read_config() -> configparser.ConfigParser:
@@ -16,7 +16,9 @@ class Config:
         config.read(Config._path)
         if not config.has_section("wordle-bot"):
             with open(Config._path, "w") as file:
-                lines = ["[wordle-bot]\n", "token=enterTokenHere\n"]
+                lines = ["[wordle-bot]\n",
+                         "token=enterTokenHere\n",
+                         "testtoken=enterTokenHere\n"]
                 file.writelines(lines)
             return Config.read_config()
         return config

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -7,6 +7,7 @@ class Config:
     def __init__(self):
         config = self.read_config()
         self.token = config.get("wordle-bot", "token")
+        self.testtoken = config.get("wordle-bot", "testtoken")
 
     @staticmethod
     def read_config() -> configparser.ConfigParser:

--- a/src/data.py
+++ b/src/data.py
@@ -23,13 +23,12 @@ class Client:
         self.subwaydle_db = self.mongo.subwaydle
 
     def get_db_by_game_abbreviation(self, game_abbreviation):
-        match game_abbreviation:
-            case "wb":
-                return self.wordle_db
-            case "wlb":
-                return self.worldle_db
-            case "sb":
-                return self.subwaydle_db
+        if game_abbreviation == "wb":
+            return self.wordle_db
+        elif game_abbreviation == "wlb":
+            return self.worldle_db
+        elif game_abbreviation == "sb":
+            return self.subwaydle_db
 
     def add_score(self, game_abbreviation: str, pid: int, wordle: str, score: int) -> bool:
         db = self.get_db_by_game_abbreviation(game_abbreviation)

--- a/src/data.py
+++ b/src/data.py
@@ -21,6 +21,7 @@ class Client:
         self.wordle_db = self.mongo.wordle
         self.worldle_db = self.mongo.worldle
         self.subwaydle_db = self.mongo.subwaydle
+        self.taylordle_db = self.mongo.taylordle
 
     def get_db_by_game_abbreviation(self, game_abbreviation):
         if game_abbreviation == "wb":
@@ -29,6 +30,8 @@ class Client:
             return self.worldle_db
         elif game_abbreviation == "sb":
             return self.subwaydle_db
+        elif game_abbreviation == "tb":
+            return self.taylordle_db
 
     def add_score(self, game_abbreviation: str, pid: int, wordle: str, score: int) -> bool:
         db = self.get_db_by_game_abbreviation(game_abbreviation)

--- a/src/data.py
+++ b/src/data.py
@@ -18,11 +18,24 @@ class Client:
     def __init__(self):
         """Initialize a new Client connected to the local MongoDB instance."""
         self.mongo = MongoClient()
-        self.db = self.mongo.wordle
+        self.wordle_db = self.mongo.wordle
+        self.worldle_db = self.mongo.worldle
+        self.subwaydle_db = self.mongo.subwaydle
 
-    def add_score(self, pid: int, wordle: str, score: int) -> bool:
+    def get_db_by_game_abbreviation(self, game_abbreviation):
+        match game_abbreviation:
+            case "wb":
+                return self.wordle_db
+            case "wlb":
+                return self.worldle_db
+            case "sb":
+                return self.subwaydle_db
+
+    def add_score(self, game_abbreviation: str, pid: int, wordle: str, score: int) -> bool:
+        db = self.get_db_by_game_abbreviation(game_abbreviation)
+
         """Adds a score to the relevant player in the database. If a score already exists, return False."""
-        player = self.db.players.find_one({'_id': pid})
+        player = db.players.find_one({'_id': pid})
         if player is not None and wordle in player["scores"]:
             return False
 
@@ -40,27 +53,31 @@ class Client:
         player["scores"][wordle] = score
         player["count"] += 1
         player["win_count"] = player["win_count"] if score == 7 else player["win_count"] + 1
-        player["average"] = player["average"] + (score - player["average"]) / (player["count"])
+        player["average"] = player["average"] + \
+            (score - player["average"]) / (player["count"])
         player["win_rate"] = player["win_count"] / player["count"]
 
-        self.db.players.replace_one({"_id": pid}, player, True)
+        db.players.replace_one({"_id": pid}, player, True)
 
         return True
 
-    def get_player_stats(self, pid: int) -> Tuple[float, int, int, float]:
+    def get_player_stats(self, game_abbreviation: str, pid: int) -> Tuple[float, int, int, float]:
         """Return the stats of the player with provided id, given as a tuple in the form
         (average, count, win_count, win_rate).
         """
-        player = self.db.players.find_one({'_id': pid})
+        db = self.get_db_by_game_abbreviation(game_abbreviation)
+
+        player = db.players.find_one({'_id': pid})
 
         if player is None:
             return 0.0, 0, 0, 0
 
         return player["average"], player["count"], player["win_count"], player["win_rate"]
 
-    def delete_player(self, pid: int) -> bool:
+    def delete_player(self, game_abbreviation: str, pid: int) -> bool:
         """Return True iff the player with pid was successfully deleted."""
-        result = self.db.players.delete_one({"_id": pid})
+        db = self.get_db_by_game_abbreviation(game_abbreviation)
+        result = db.players.delete_one({"_id": pid})
         if result.deleted_count != 0:
             return True
         return False

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import sys
 import configuration
 import data
 import discord
@@ -21,46 +22,55 @@ async def on_message(message):
     if message.author == client.user:
         return
 
-    if message.content == "!wb members":
-        await message.channel.send(message.guild.members)
+    if message.content.startswith("!wb") or message.content.startswith("Wordle"):
+        await process_message("wb", ":book: Wordle", "Wordle [0-9]+ [1-6|X]/6", message)
+    elif message.content.startswith("!wlb") or message.content.startswith("#Worldle"):
+        await process_message("wlb", ":earth_americas: Worldle", "#Worldle #[0-9]+ [1-6|X]/6", message)
+    elif message.content.startswith("!sb") or message.content.startswith("Subwaydle"):
+        await process_message("sb", ":metro: Subwaydle", "Subwaydle [0-9]+ [1-6|X]/6", message)
 
-    if message.content == "!wb me":
-        stats = database.get_player_stats(message.author.id)
+
+async def process_message(game_abbreviation, game_name, game_regex_string, message):
+    if message.content == f"!{game_abbreviation} me":
+        stats = database.get_player_stats(game_abbreviation, message.author.id)
         player = message.author.nick if message.author.nick is not None else message.author.name
-        stats_string = f"{player}'s average number of guesses is {round(stats[0], 4)}. They've played {stats[1]} " \
-                       f"games and won {stats[2]} games, making their win rate {round(stats[3] * 100, 4)}%."
+        stats_string = f"For **{game_name}**, {player}'s average number of guesses is **{round(stats[0], 4)}**. " \
+                       f"They've played **{stats[1]}** games and won **{stats[2]}** games, making their win rate " \
+                       f"**{round(stats[3] * 100, 4)}%**."
         await message.channel.send(stats_string)
 
-    if message.content == "!wb average":
-        await message.channel.send(rankings_by_average(message, 10))
+    if message.content == f"!{game_abbreviation} average":
+        await message.channel.send(f"For **{game_name}**:\n{rankings_by_average(message, game_abbreviation, 10)}")
 
-    if message.content == "!wb rate":
-        await message.channel.send(rankings_by_win_rate(message, 10))
+    if message.content == f"!{game_abbreviation} rate":
+        await message.channel.send(f"For **{game_name}**:\n{rankings_by_win_rate(message, game_abbreviation, 10)}")
 
-    if message.content == "!wb games":
-        await message.channel.send(rankings_by_games_played(message, 10))
+    if message.content == f"!{game_abbreviation} games":
+        await message.channel.send(f"For **{game_name}**:\n{rankings_by_games_played(message, game_abbreviation, 10)}")
 
-    if message.content == "!wb deletemydata":
-        if database.delete_player(message.author.id):
+    if message.content == f"!{game_abbreviation} deletemydata":
+        if database.delete_player(game_abbreviation, message.author.id):
             await message.channel.send(
                 f"{message.author.nick if message.author.nick is not None else message.author.name}'s "
                 f"data has been deleted.")
         else:
             await message.channel.send("I tried to delete your data, but I couldn't find any data for you!")
 
-    if message.content == "!wb helper":
+    if message.content == f"!{game_abbreviation} helper":
         await message.channel.send('https://www.spalmurray.com/wordle-helper')
 
-    if message.content == "!wb help" or message.content == "!wb":
-        help_string = "`!wb help` to see this message\n" \
-                      "`!wb me` to see your stats\n" \
-                      "`!wb average` to see server rankings by average number of guesses\n" \
-                      "`!wb rate` to see server rankings by win rate\n" \
-                      "`!wb games` to see server rankings by games played\n" \
-                      "`!wb deletemydata` to remove all your scores from wordle-bot (warning: this is not reversible!)"
+    if message.content == f"!{game_abbreviation} help" or message.content == f"!{game_abbreviation}":
+        # backticks are Discord/Markdown characters for fixed width code type display
+        help_string = f"`!{game_abbreviation} help` to see this message\n" \
+                      f"`!{game_abbreviation} me` to see your stats\n" \
+                      f"`!{game_abbreviation} average` to see server rankings by average number of guesses\n" \
+                      f"`!{game_abbreviation} rate` to see server rankings by win rate\n" \
+                      f"`!{game_abbreviation} games` to see server rankings by games played\n" \
+                      f"`!{game_abbreviation} deletemydata` to remove all your scores from wordle-bot (warning: this is not reversible!)"
         await message.channel.send(help_string)
 
-    if re.match(r"Wordle [0-9]+ [1-6|X]/6", message.content) is not None:
+    game_regex = re.compile(game_regex_string)
+    if re.match(game_regex, message.content) is not None:
         # extract the Wordle number from message
         wordle = message.content.splitlines()[0].split(" ")[1]
         # extract the score from message
@@ -69,10 +79,11 @@ async def on_message(message):
             score = "7"
         score = int(score)
 
-        result = database.add_score(message.author.id, wordle, score)
+        result = database.add_score(
+            game_abbreviation, message.author.id, wordle, score)
 
         if not result:
-            await message.channel.send("You've already submitted a score for this Wordle.")
+            await message.channel.send(f"You've already submitted a score for this {game_name}.")
             return
 
         if score == 1:
@@ -91,7 +102,7 @@ async def on_message(message):
             await message.channel.send("I will pretend like I didn't see that one...")
 
 
-def rankings_by_average(message, n: int) -> str:
+def rankings_by_average(message, game_abbreviation: str, n: int) -> str:
     """Return string formatted leaderboard ordered by average guesses where message is the message data from the
     triggering Discord message and n is the max number of rankings to return.
     """
@@ -99,7 +110,7 @@ def rankings_by_average(message, n: int) -> str:
                for member in message.guild.members]
     scores = []
     for member in members:
-        score = database.get_player_stats(member[1])
+        score = database.get_player_stats(game_abbreviation, member[1])
         if score[0] == 0:
             continue
         scores.append((member[0], score))
@@ -108,13 +119,13 @@ def rankings_by_average(message, n: int) -> str:
     scoreboard = "Rankings by average number of guesses:"
     i = 0
     while i < n and i != len(scores):
-        scoreboard += f"\n{i + 1}. {scores[i][0]} ({round(scores[i][1][0], 4)})"
+        scoreboard += f"\n{i + 1}. **{scores[i][0]}** ({round(scores[i][1][0], 4)})"
         i += 1
 
     return scoreboard
 
 
-def rankings_by_win_rate(message, n: int) -> str:
+def rankings_by_win_rate(message, game_abbreviation: str, n: int) -> str:
     """Return string formatted leaderboard ordered by win rate where message is the message data from the
     triggering Discord message and n is the max number of rankings to return.
     """
@@ -122,7 +133,7 @@ def rankings_by_win_rate(message, n: int) -> str:
                for member in message.guild.members]
     scores = []
     for member in members:
-        score = database.get_player_stats(member[1])
+        score = database.get_player_stats(game_abbreviation, member[1])
         if score[0] == 0:
             continue
         scores.append((member[0], score))
@@ -131,13 +142,13 @@ def rankings_by_win_rate(message, n: int) -> str:
     scoreboard = "Rankings by win rate:"
     i = 0
     while i < n and i != len(scores):
-        scoreboard += f"\n{i + 1}. {scores[i][0]} ({round(scores[i][1][3] * 100, 4)}%)"
+        scoreboard += f"\n{i + 1}. **{scores[i][0]}** ({round(scores[i][1][3] * 100, 4)}%)"
         i += 1
 
     return scoreboard
 
 
-def rankings_by_games_played(message, n: int) -> str:
+def rankings_by_games_played(message, game_abbreviation: str, n: int) -> str:
     """Return string formatted leaderboard ordered by number of games played where message is the message data from the
     triggering Discord message and n is the max number of rankings to return.
     """
@@ -145,7 +156,7 @@ def rankings_by_games_played(message, n: int) -> str:
                for member in message.guild.members]
     scores = []
     for member in members:
-        score = database.get_player_stats(member[1])
+        score = database.get_player_stats(game_abbreviation, member[1])
         if score[0] == 0:
             continue
         scores.append((member[0], score))
@@ -154,7 +165,7 @@ def rankings_by_games_played(message, n: int) -> str:
     scoreboard = "Rankings by games played:"
     i = 0
     while i < n and i != len(scores):
-        scoreboard += f"\n{i + 1}. {scores[i][0]} ({scores[i][1][1]})"
+        scoreboard += f"\n{i + 1}. **{scores[i][0]}** ({scores[i][1][1]})"
         i += 1
 
     return scoreboard
@@ -162,4 +173,9 @@ def rankings_by_games_played(message, n: int) -> str:
 
 if __name__ == "__main__":
     config = configuration.Config()
-    client.run(config.token)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--test":
+        client.run(config.testtoken)
+
+    else:
+        client.run(config.token)

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,8 @@ async def on_message(message):
         await process_message("wlb", ":earth_americas: Worldle", "#Worldle #[0-9]+ [1-6|X]/6", message)
     elif message.content.startswith("!sb") or message.content.startswith("Subwaydle"):
         await process_message("sb", ":metro: Subwaydle", "Subwaydle [0-9]+ [1-6|X]/6", message)
+    elif message.content.startswith("!tb") or message.content.startswith("Taylordle"):
+        await process_message("tb", ":notes: Taylordle", "Taylordle [0-9]+ [1-6|X]/6", message)
 
 
 async def process_message(game_abbreviation, game_name, game_regex_string, message):

--- a/src/main.py
+++ b/src/main.py
@@ -32,11 +32,7 @@ async def on_message(message):
 
 async def process_message(game_abbreviation, game_name, game_regex_string, message):
     if message.content == f"!{game_abbreviation} me":
-        stats = database.get_player_stats(game_abbreviation, message.author.id)
-        player = message.author.nick if message.author.nick is not None else message.author.name
-        stats_string = f"For **{game_name}**, {player}'s average number of guesses is **{round(stats[0], 4)}**. " \
-                       f"They've played **{stats[1]}** games and won **{stats[2]}** games, making their win rate " \
-                       f"**{round(stats[3] * 100, 4)}%**."
+        stats_string = get_stats_string(game_abbreviation, game_name, message)
         await message.channel.send(stats_string)
 
     if message.content == f"!{game_abbreviation} average":
@@ -84,9 +80,7 @@ async def process_message(game_abbreviation, game_name, game_regex_string, messa
 
         if not result:
             await message.channel.send(f"You've already submitted a score for this {game_name}.")
-            return
-
-        if score == 1:
+        elif score == 1:
             await message.channel.send("Uh... you should probably go buy a lottery ticket...")
         elif score == 2:
             await message.channel.send("Wow! That's impressive!")
@@ -100,6 +94,17 @@ async def process_message(game_abbreviation, game_name, game_regex_string, messa
             await message.channel.send("Cutting it a little close there...")
         else:
             await message.channel.send("I will pretend like I didn't see that one...")
+
+        await message.channel.send(get_stats_string(game_abbreviation, game_name, message))
+
+
+def get_stats_string(game_abbreviation, game_name, message):
+    stats = database.get_player_stats(game_abbreviation, message.author.id)
+    player = message.author.nick if message.author.nick is not None else message.author.name
+    stats_string = f"For {game_name}:\n**{player}**: **{stats[2]}** wins out of **{stats[1]}** games played " \
+        f" (**{round(stats[3] * 100, 4)}%**), averaging **{round(stats[0], 4)}** guesses."
+
+    return stats_string
 
 
 def rankings_by_average(message, game_abbreviation: str, n: int) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -190,8 +190,14 @@ if __name__ == "__main__":
 
     if len(sys.argv) > 1 and sys.argv[1] == "--test":
         isTest = True
-        client.run(config.testtoken)
+        if config.testtoken == None:
+            print("Set \"testtoken\" value in config.ini to the token value from Discord developer site at https://discord.com/developers/applications/<application id>/bot")
+        else:
+            client.run(config.testtoken)
 
     else:
         isTest = False
-        client.run(config.token)
+        if config.token == None:
+            print("Set \"token\" value in config.ini to the token value from Discord developer site at https://discord.com/developers/applications/<application id>/bot")
+        else:
+            client.run(config.token)

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,10 @@ async def on_ready():
 
 
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
+    if isTest and not message.channel.name == "wordle-test":
+        return
+
     if message.author == client.user:
         return
 
@@ -64,7 +67,9 @@ async def process_message(game_abbreviation, game_name, game_regex_string, messa
                       f"`!{game_abbreviation} average` to see server rankings by average number of guesses\n" \
                       f"`!{game_abbreviation} rate` to see server rankings by win rate\n" \
                       f"`!{game_abbreviation} games` to see server rankings by games played\n" \
-                      f"`!{game_abbreviation} deletemydata` to remove all your scores from wordle-bot (warning: this is not reversible!)"
+                      f"`!{game_abbreviation} deletemydata` to remove all your scores from wordle-bot (warning: this is not reversible!)\n" \
+                      f"I support multiple games now! Try the above commands with `!wb` (:book: Wordle), `!wlb` (:earth_americas: Worldle), " \
+                      f"`!sb` (:metro: Subwaydle), and `!tb` (:notes: Taylordle)."
         await message.channel.send(help_string)
 
     game_regex = re.compile(game_regex_string)
@@ -179,10 +184,14 @@ def rankings_by_games_played(message, game_abbreviation: str, n: int) -> str:
 
 
 if __name__ == "__main__":
+    global isTest
+
     config = configuration.Config()
 
     if len(sys.argv) > 1 and sys.argv[1] == "--test":
+        isTest = True
         client.run(config.testtoken)
 
     else:
+        isTest = False
         client.run(config.token)


### PR DESCRIPTION
No idea if you're open to pull requests, but my group plays Wordle, Subwaydle, Worldle, and one guy plays Taylordle (the Taylor Swift one), so I refactored a bunch of stuff to make this work for all of them:
* The db class now takes the game abbreviation (`wb`, `wlb`, `sb`, or `tb`) as a method parameter and matches up the Mongo db based on that. 
* The `on_message` function has been refactored to catch the game type being requested and pass the abbreviation, full name, and customized regex (because Subwaydle puts # chars before the name and game number). 
* I also tightened up some of the stats output, added emoji and bolding to names and stat values, and added a `--test` command line parameter so I could test this alongside a running instance in a separate Discord channel. 
* Also, I added some installation steps to the readme, because who knows how long it'll take Discord to approve your public service?! Could be ages, for all we know, right?

A bunch of this could probably be cleaner, but I don't actually know Python. This is my first attempt at using it, but it's similar enough to everything else, I guess. One could probably put all the games in one DB and use different collections instead, but the main one was already called "wordle", and I didn't want to break anyone's existing database arrangement. I didn't know what to do with `!wb members` since it never worked for me on my 80 person server because the results were too large for one message and Discord threw an error. I think I just removed it altogether.

Anyway, let me know what you think!