### PR TITLE
Fix Wordle score regex to include commas

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -82,6 +82,7 @@ async def on_message(message):
                       "`!wb deletemydata` to remove all your scores from wordle-bot (warning: this is not reversible!)"
         await message.channel.send(help_string)
 
+    message.content = (message.content or '').replace(',', '')
     if re.match(r"Wordle [0-9]+ [1-6|X]/6", message.content) is not None:
         # extract the Wordle number from message
         wordle = message.content.splitlines()[0].split(" ")[1]


### PR DESCRIPTION
On March 15th, Wordle showed its 1,000th puzzle. This changed the formatting of shareable scores a bit, to:

```
Wordle 1,001 3/6

⬛⬛⬛🟨⬛
⬛🟩⬛⬛🟨
🟩🟩🟩🟩🟩
```


The cause of failure is that Wordle Bot does not account for commas in the puzzle number.

This PR improves the regex so that messages can be properly detected in chat again